### PR TITLE
Add NM-SGD optimizer

### DIFF
--- a/parq/optim/__init__.py
+++ b/parq/optim/__init__.py
@@ -2,9 +2,41 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-
 from .binarelax import ProxBinaryRelax  # noqa: F401
 from .parq import ProxPARQ  # noqa: F401
 from .proxmap import ProxHardQuant, ProxMap  # noqa: F401
-from .quantopt import QuantOptimizer  # noqa: F401
+from .quantopt import QuantOptimizer   # noqa: F401
+from .nm_sgd import NMSGDOptimizer  # noqa: F401
 from .softquant import ProxSoftQuant  # noqa: F401
+from ..quant import Quantizer
+
+
+from functools import partial
+from torch.optim import Optimizer
+
+def build_quant_optimizer(
+    base_optimizer: Optimizer,
+    quantizer: Quantizer,
+    prox_map: ProxMap,
+    warmup_steps: int = 0,
+    quant_period: int = 10,
+    quant_per_channel: bool = False,
+    quant_shrink: bool = False,
+    anneal_wd_frac: float = 0.0,
+    nm_gamma: float = 0.0,
+) -> QuantOptimizer:
+    if nm_gamma > 0:
+        prune_opt_cls = partial(NMSGDOptimizer, nm_gamma=nm_gamma)
+    else: 
+        prune_opt_cls = QuantOptimizer
+
+    return prune_opt_cls(
+        base_optimizer=base_optimizer,
+        quantizer=quantizer,
+        prox_map=prox_map,
+        warmup_steps=warmup_steps,
+        quant_period=quant_period,
+        quant_per_channel=quant_per_channel,
+        quant_shrink=quant_shrink,
+        anneal_wd_frac=anneal_wd_frac,
+    )

--- a/parq/optim/nm_sgd.py
+++ b/parq/optim/nm_sgd.py
@@ -1,0 +1,58 @@
+import torch
+from torch import Tensor
+from torch.optim import Optimizer
+
+from .quantopt import QuantOptimizer
+from .proxmap import ProxMap
+from ..quant import Quantizer
+
+class NMSGDOptimizer(QuantOptimizer):
+    """From "A Normal Map-Based Proximal Stochastic Gradient Method": https://arxiv.org/pdf/2305.05828v2
+    Other parameters:
+        norm_gamma: float, default -1.0
+            If > 0, then normalize gamma by parameter group dimension.
+            This is the same as the "normalized" option in N:M sparsity.
+    """
+
+    def __init__(
+        self,
+        base_optimizer: Optimizer,
+        quantizer: Quantizer,
+        prox_map: ProxMap,
+        warmup_steps: int = 0,
+        quant_period: int = 10,
+        quant_per_channel: bool = False,
+        quant_shrink: bool = False,
+        anneal_wd_frac: float = 0.0,
+        nm_gamma: float = 0.0,
+    ) -> None:
+        super().__init__(
+            base_optimizer=base_optimizer,
+            quantizer=quantizer,
+            prox_map=prox_map,
+            warmup_steps=warmup_steps,
+            quant_period=quant_period,
+            quant_per_channel=quant_per_channel,
+            quant_shrink=quant_shrink,
+            anneal_wd_frac=anneal_wd_frac,
+        )
+        self.nm_gamma = nm_gamma
+        for group in self.regularized_param_groups():
+            group["gamma"] = self.nm_gamma
+
+    def _get_gamma(self, group):
+        return self.nm_gamma
+
+    @torch._disable_dynamo
+    def restore_latent_params(self) -> None:
+        """Restore latent parameters as optimizer parameters"""
+        for group in self.regularized_param_groups():
+            for p in group["params"]:
+                if p.requires_grad:
+                    self.state[p]["corrections"] = self.state[p]["latent"] - p
+                    p.copy_(self.state[p]["latent"])
+
+    def _correct_param(self, p: Tensor, group) -> None:
+        if "corrections" in self.state[p]:
+            stepsize = -1.0 * group["lr"] / self.nm_gamma
+            p.add_(self.state[p]["corrections"], alpha=stepsize)


### PR DESCRIPTION
Adding NM-SGD optimizer for quantization.
<img width="1281" height="1029" alt="image" src="https://github.com/user-attachments/assets/db7fdeed-2b83-416e-9769-bd1b38561021" />
<img width="1220" height="965" alt="image" src="https://github.com/user-attachments/assets/4c56dc7b-8956-41d0-bc50-758f50f2eb6c" />

The above accuracy / loss plots are generated with this command:
```bash
srun torchrun \
  --nnodes $N_NODE \
  --nproc-per-node $N_GPU_PER_NODE \
  --rdzv-id $SEED \
  --rdzv-backend c10d \
  --rdzv-endpoint $head_node_ip:29500 \
  -m examples.qat_vit_imagenet \
    --arch deit_tiny_patch16_224 \
    --batch-size $BATCH_SIZE \
    --save-dir $SAVE_DIR \
    --resume $SAVE_DIR/checkpoint.pth \
    --seed $SEED \
    --lr 2e-3 \
    --lr-min 1e-8 \
    --quant-bits 2 \
    --quant-method lsbq \
    --nm-gamma 1.0 \
    --quant-proxmap parq \
    --quant-per-channel \
    --anneal-steepness 50 \
    --custom-train-transform \
    --cutmix-mixup \
    --torch-compile \
    --amp \
    || ret=$?
```