### PR TITLE
Fix: make resnet cifar10 example runnable by adding parser options

### DIFF
--- a/examples/qat_resnet_cifar10.py
+++ b/examples/qat_resnet_cifar10.py
@@ -350,6 +350,12 @@ def get_arg_parser():
         help="weight decay (default: 1e-4)",
     )
     parser.add_argument(
+        "--anneal-wd-frac",
+        type=float,
+        default=0.0,
+        help="fraction of weight decay to anneal during QAT (default: 0.0)",
+    )
+    parser.add_argument(
         "--full-prec",
         action="store_true",
         help="use full-precision training",


### PR DESCRIPTION
Problem:
The Cifar10 Resnet example in the file `qat_resnet_cifar10.py` is currently not runnable.

The `build_quant_optimizer` function expects `args` to have a `anneal_wd_frac` attribute, which the parser does not know.


https://github.com/facebookresearch/parq/blob/ac256d90918d1ebab77da7b4ce2834e8a0850cec/examples/qat_resnet_cifar10.py#L145-L147


Adding the argument from the imagenet example fixes this.

